### PR TITLE
ci: add GitHub Actions CI workflow for automated testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run tests
+        run: uv run pytest tests/ -v

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mmoney-cli
 
+![CI](https://github.com/theFong/mmoney-cli/actions/workflows/ci.yml/badge.svg)
+
 CLI for [Monarch Money](https://www.monarchmoney.com) - access your financial data from the command line.
 
 Built on top of [monarchmoneycommunity](https://github.com/bradleyseanf/monarchmoneycommunity).


### PR DESCRIPTION
Add CI pipeline that runs pytest on Python 3.9, 3.10, 3.11, 3.12 using uv for dependency management. Triggered on push to main and all PRs.

Closes #2